### PR TITLE
Update to nodejs 12

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,1 +1,1 @@
-node bin/www
+node --tls-min-v1.0 bin/www


### PR DESCRIPTION
In the newest version of nodejs (12), they deprecated tls1.0 and made 1.3 default..  that causes the script to fail because of https this parameter fixes it